### PR TITLE
Improved POSIX compliance

### DIFF
--- a/randomquote
+++ b/randomquote
@@ -3,12 +3,12 @@ function randomquote {
     local THEME='wow'
     local BASE_PATH="$(dirname $0)"
     local QUOTE_FILES="${BASE_PATH}/.quotes.d/${THEME}.quotes"
-    
+
     ## POSIX Compliant
     local LIM=`cat "${QUOTE_FILES}" | wc -l`
     local NUM=`echo $(( $RANDOM % $LIM +1 ))`
     local QUOTE=`sed -n $NUM'p' ${QUOTE_FILES}`
-    echo -e "\e[1m \e[31m${QUOTE}"
+    printf "\e[1m \e[31m${QUOTE}\n"
 }
 
 # FUNC EXEC


### PR DESCRIPTION
echo -e is not standard posix even though it is implemented
by gnu echo, bash echo and zsh echo.

http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html#tag_20_94
